### PR TITLE
[Feat] #20 - CoreData xcdatamodeld 파일 추가 및 Entities 정의

### DIFF
--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -5,4 +5,9 @@
         <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
     </entity>
+    <entity name="PaymentMethod" representedClassName="PaymentMethod" syncable="YES">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+    </entity>
 </model>

--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -1,2 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G231" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier=""/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G231" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Category" representedClassName="Category" syncable="YES">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+    </entity>
+</model>

--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G231" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G231" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Category" representedClassName="Category" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -10,4 +10,13 @@
         <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
     </entity>
+    <entity name="RecurringData" representedClassName="RecurringData" syncable="YES">
+        <attribute name="amount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="content" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="type" attributeType="String"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
 </model>

--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G231" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier=""/>

--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -4,11 +4,15 @@
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
+        <relationship name="recurringData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="RecurringData" inverseName="category" inverseEntity="RecurringData"/>
+        <relationship name="transactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Transaction" inverseName="category" inverseEntity="Transaction"/>
     </entity>
     <entity name="PaymentMethod" representedClassName="PaymentMethod" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isDefault" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
+        <relationship name="recurringData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="RecurringData" inverseName="paymentMethod" inverseEntity="RecurringData"/>
+        <relationship name="transactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Transaction" inverseName="paymentMethod" inverseEntity="Transaction"/>
     </entity>
     <entity name="RecurringData" representedClassName="RecurringData" syncable="YES">
         <attribute name="amount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -18,6 +22,9 @@
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="type" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="category" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="recurringData" inverseEntity="Category"/>
+        <relationship name="paymentMethod" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PaymentMethod" inverseName="recurringData" inverseEntity="PaymentMethod"/>
+        <relationship name="transaction" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Transaction" inverseName="recurringData" inverseEntity="Transaction"/>
     </entity>
     <entity name="Transaction" representedClassName="Transaction" syncable="YES">
         <attribute name="amount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -32,5 +39,8 @@
         <attribute name="recurringRule" optional="YES" attributeType="String"/>
         <attribute name="type" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="category" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="transactions" inverseEntity="Category"/>
+        <relationship name="paymentMethod" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PaymentMethod" inverseName="transactions" inverseEntity="PaymentMethod"/>
+        <relationship name="recurringData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="RecurringData" inverseName="transaction" inverseEntity="RecurringData"/>
     </entity>
 </model>

--- a/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
+++ b/BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld/BillKeeper.xcdatamodel/contents
@@ -19,4 +19,18 @@
         <attribute name="type" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
+    <entity name="Transaction" representedClassName="Transaction" syncable="YES">
+        <attribute name="amount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="content" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="expiredDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="installmentMonths" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isInstallment" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isRecurring" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="recurringRule" optional="YES" attributeType="String"/>
+        <attribute name="type" attributeType="String"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
 </model>

--- a/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity+.swift
@@ -1,0 +1,43 @@
+//
+//  CategoryEntity+.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+extension CategoryEntity {
+  @nonobjc class func fetchRequest() -> NSFetchRequest<CategoryEntity> {
+    return NSFetchRequest<CategoryEntity>(entityName: "Category")
+  }
+}
+
+extension CategoryEntity {
+  @objc(addRecurringDataObject:)
+  @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
+  
+  @objc(removeRecurringDataObject:)
+  @NSManaged func removeFromRecurringData(_ value: RecurringDataEntity)
+  
+  @objc(addRecurringData:)
+  @NSManaged func addToRecurringData(_ values: NSSet)
+  
+  @objc(removeRecurringData:)
+  @NSManaged func removeFromRecurringData(_ values: NSSet)
+}
+
+extension CategoryEntity {
+  @objc(addTransactionsObject:)
+  @NSManaged func addToTransactions(_ value: TransactionEntity)
+  
+  @objc(removeTransactionsObject:)
+  @NSManaged func removeFromTransactions(_ value: TransactionEntity)
+  
+  @objc(addTransactions:)
+  @NSManaged func addToTransactions(_ values: NSSet)
+  
+  @objc(removeTransactions:)
+  @NSManaged func removeFromTransactions(_ values: NSSet)
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity.swift
@@ -1,0 +1,18 @@
+//
+//  CategoryEntity.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+@objc(Category)
+final class CategoryEntity: NSManagedObject {
+  @NSManaged var id: UUID
+  @NSManaged var isDefault: Bool
+  @NSManaged var name: String
+  @NSManaged var recurringData: NSSet?
+  @NSManaged var transactions: NSSet?
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
@@ -1,0 +1,43 @@
+//
+//  PaymentMethodEntity+.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+extension PaymentMethodEntity {
+  @nonobjc class func fetchRequest() -> NSFetchRequest<PaymentMethodEntity> {
+    return NSFetchRequest<PaymentMethodEntity>(entityName: "PaymentMethod")
+  }
+}
+
+extension PaymentMethodEntity {
+  @objc(addRecurringDataObject:)
+  @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
+  
+  @objc(removeRecurringDataObject:)
+  @NSManaged func removeFromRecurringData(_ value: RecurringDataEntity)
+  
+  @objc(addRecurringData:)
+  @NSManaged func addToRecurringData(_ values: NSSet)
+  
+  @objc(removeRecurringData:)
+  @NSManaged func removeFromRecurringData(_ values: NSSet)
+}
+
+extension PaymentMethodEntity {
+  @objc(addTransactionsObject:)
+  @NSManaged func addToTransactions(_ value: TransactionEntity)
+  
+  @objc(removeTransactionsObject:)
+  @NSManaged func removeFromTransactions(_ value: TransactionEntity)
+  
+  @objc(addTransactions:)
+  @NSManaged func addToTransactions(_ values: NSSet)
+  
+  @objc(removeTransactions:)
+  @NSManaged func removeFromTransactions(_ values: NSSet)
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity.swift
@@ -1,0 +1,18 @@
+//
+//  PaymentMethodEntity.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+@objc(PaymentMethod)
+final class PaymentMethodEntity: NSManagedObject {
+  @NSManaged var id: UUID
+  @NSManaged var isDefault: Bool
+  @NSManaged var name: String
+  @NSManaged var recurringData: NSSet?
+  @NSManaged var transactions: NSSet?
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity+.swift
@@ -1,0 +1,15 @@
+//
+//  RecurringDataEntity+.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+extension RecurringDataEntity {
+  @nonobjc class func fetchRequest() -> NSFetchRequest<RecurringDataEntity> {
+    return NSFetchRequest<RecurringDataEntity>(entityName: "RecurringData")
+  }
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity.swift
@@ -1,0 +1,23 @@
+//
+//  RecurringDataEntity.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+@objc(RecurringData)
+final class RecurringDataEntity: NSManagedObject {
+  @NSManaged var amount: Int64
+  @NSManaged var content: String
+  @NSManaged var createdAt: Date
+  @NSManaged var date: Date
+  @NSManaged var id: UUID
+  @NSManaged var type: String
+  @NSManaged var updatedAt: Date
+  @NSManaged var category: CategoryEntity?
+  @NSManaged var paymentMethod: PaymentMethodEntity?
+  @NSManaged var transaction: TransactionEntity?
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/TransactionEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/TransactionEntity+.swift
@@ -1,0 +1,29 @@
+//
+//  TransactionEntity+.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+extension TransactionEntity {
+  @nonobjc class func fetchRequest() -> NSFetchRequest<TransactionEntity> {
+    return NSFetchRequest<TransactionEntity>(entityName: "Transaction")
+  }
+}
+
+extension TransactionEntity {
+  @objc(addRecurringDataObject:)
+  @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
+  
+  @objc(removeRecurringDataObject:)
+  @NSManaged func removeFromRecurringData(_ value: RecurringDataEntity)
+  
+  @objc(addRecurringData:)
+  @NSManaged func addToRecurringData(_ values: NSSet)
+  
+  @objc(removeRecurringData:)
+  @NSManaged func removeFromRecurringData(_ values: NSSet)
+}

--- a/BillKeeper/Sources/Data/Persistent/Entities/TransactionEntity.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/TransactionEntity.swift
@@ -1,0 +1,28 @@
+//
+//  TransactionEntity.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+//
+
+import CoreData
+
+@objc(Transaction)
+final class TransactionEntity: NSManagedObject {
+  @NSManaged var amount: Int64
+  @NSManaged var content: String
+  @NSManaged var createdAt: Date
+  @NSManaged var date: Date
+  @NSManaged var expiredDate: Date?
+  @NSManaged var id: UUID
+  @NSManaged var installmentMonths: Int16
+  @NSManaged var isInstallment: Bool
+  @NSManaged var isRecurring: Bool
+  @NSManaged var recurringRule: String?
+  @NSManaged var type: String
+  @NSManaged var updatedAt: Date
+  @NSManaged var category: CategoryEntity?
+  @NSManaged var paymentMethod: PaymentMethodEntity?
+  @NSManaged var recurringData: NSSet?
+}

--- a/Project.swift
+++ b/Project.swift
@@ -60,7 +60,7 @@ let project = Project(
       bundleId: "com.iOSGrowthLab.BillKeeperTests",
       infoPlist: .default,
       sources: ["BillKeeper/Tests/**"],
-      resources: [],
+      resources: ["BillKeeper/Resources/Data/CoreData/BillKeeper.xcdatamodeld"],
       dependencies: [.target(name: "BillKeeper")]
     )
   ],


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #20 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- CoreData xcdatamodeld 파일을 추가하고 Tuist Project Resource에 포함하였습니다.
- CoreData Entities를 정의하고 각 Entities의 관계를 정의했습니다.
- CoreData Entities의 NSManagedObject 클래스를 정의했습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- CoreData 모델 구조와 각 Entity 간 관계 설정이 올바른지 검토했습니다..
- Tuist에서 xcdatamodeld 리소스가 정상적으로 포함되고 빌드되는지 확인했습니다.
- 향후 확장성과 마이그레이션을 고려해 Entity 구조를 설계했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- SwiftData 전환은 고려하지 않아, CoreData의 SwiftData 사용은 비활성화 했습니다.
- Entity 확장 및 변경 시에는 xcdatamodeld 내 Model Version을 통해 마이그레이션을 관리할 예정입니다.
- 아래 첨부된 ERD는 초기 기획 단계에서 설계된 CoreData 구조이며, 실제 구현된 .xcdatamodeld와 동일한 관계를 가집니다.
  ERD에서는 Int 등과 같은 포괄적인 데이터 타입만 정의하였으며, 실제 구현에서 Int16, Int64 등 Attribute의 세부 타입을 지정했습니다.
<img width="2800" height="1024" alt="CoreData ERD" src="https://github.com/user-attachments/assets/0dfd0b97-2e76-45c6-95c9-35803eb8ca3a" />

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
- [x] 컴파일 정상 확인
