### PR TITLE
[Feat] #22 - Category / PaymentMethod RepositoryImpl 구현체 구현

### DIFF
--- a/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity+.swift
@@ -9,12 +9,22 @@
 import CoreData
 
 extension CategoryEntity {
+  // MARK: - Fetch Request
+  
   @nonobjc class func fetchRequest() -> NSFetchRequest<CategoryEntity> {
     return NSFetchRequest<CategoryEntity>(entityName: "Category")
   }
-}
-
-extension CategoryEntity {
+  
+  // MARK: - Domain Mapping
+  
+  func toDomain() -> Category {
+    return Category(id: id,
+                    name: name,
+                    isDefault: isDefault)
+  }
+  
+  // MARK: - RecurringData Relationship
+  
   @objc(addRecurringDataObject:)
   @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
   
@@ -26,9 +36,9 @@ extension CategoryEntity {
   
   @objc(removeRecurringData:)
   @NSManaged func removeFromRecurringData(_ values: NSSet)
-}
-
-extension CategoryEntity {
+  
+  // MARK: - Transactions Relationship
+  
   @objc(addTransactionsObject:)
   @NSManaged func addToTransactions(_ value: TransactionEntity)
   

--- a/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
@@ -9,7 +9,7 @@
 import CoreData
 
 extension PaymentMethodEntity {
-  // MARK: - FetchRequest
+  // MARK: - Fetch Request
   
   @nonobjc class func fetchRequest() -> NSFetchRequest<PaymentMethodEntity> {
     return NSFetchRequest<PaymentMethodEntity>(entityName: "PaymentMethod")

--- a/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
@@ -9,12 +9,22 @@
 import CoreData
 
 extension PaymentMethodEntity {
+  // MARK: - FetchRequest
+  
   @nonobjc class func fetchRequest() -> NSFetchRequest<PaymentMethodEntity> {
     return NSFetchRequest<PaymentMethodEntity>(entityName: "PaymentMethod")
   }
-}
-
-extension PaymentMethodEntity {
+  
+  // MARK: - Domain Mapping
+  
+  func toDomain() -> PaymentMethod {
+    return PaymentMethod(id: id,
+                         name: name,
+                         isDefault: isDefault)
+  }
+  
+  // MARK: - RecurringData Relationship
+  
   @objc(addRecurringDataObject:)
   @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
   
@@ -26,9 +36,9 @@ extension PaymentMethodEntity {
   
   @objc(removeRecurringData:)
   @NSManaged func removeFromRecurringData(_ values: NSSet)
-}
-
-extension PaymentMethodEntity {
+  
+  // MARK: - Transactions Relationship
+  
   @objc(addTransactionsObject:)
   @NSManaged func addToTransactions(_ value: TransactionEntity)
   

--- a/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity+.swift
@@ -9,6 +9,8 @@
 import CoreData
 
 extension RecurringDataEntity {
+  // MARK: - Fetch Request
+  
   @nonobjc class func fetchRequest() -> NSFetchRequest<RecurringDataEntity> {
     return NSFetchRequest<RecurringDataEntity>(entityName: "RecurringData")
   }

--- a/BillKeeper/Sources/Data/Persistent/Repositories/CategoryRepositoryImpl.swift
+++ b/BillKeeper/Sources/Data/Persistent/Repositories/CategoryRepositoryImpl.swift
@@ -1,0 +1,75 @@
+//
+//  CategoryRepositoryImpl.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/27/25.
+//
+
+import CoreData
+
+final class CategoryRepositoryImpl: CategoryRepository {
+  private let context: NSManagedObjectContext
+  
+  init(context: NSManagedObjectContext) {
+    self.context = context
+  }
+  
+  func fetchAll() async throws -> [Category] {
+    try await context.perform {
+      let request = CategoryEntity.fetchRequest()
+      let entities = try self.context.fetch(request)
+      return entities.map { $0.toDomain() }
+    }
+  }
+  
+  func fetch(by id: UUID) async throws -> Category? {
+    try await context.perform {
+      let request = CategoryEntity.fetchRequest()
+      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+      request.fetchLimit = 1
+      let entity = try self.context.fetch(request).first
+      return entity?.toDomain()
+    }
+  }
+  
+  func save(_ category: Category) async throws {
+    try await context.perform {
+      let entity = CategoryEntity(context: self.context)
+      entity.id = category.id
+      entity.name = category.name
+      entity.isDefault = category.isDefault
+      try self.context.save()
+    }
+  }
+  
+  func update(_ category: Category) async throws {
+    try await context.perform {
+      let request = CategoryEntity.fetchRequest()
+      request.predicate = NSPredicate(format: "id == %@", category.id as CVarArg)
+      request.fetchLimit = 1
+      
+      guard let entity = try self.context.fetch(request).first else {
+        throw RepositoryError.notFound
+      }
+      
+      entity.name = category.name
+      entity.isDefault = category.isDefault
+      try self.context.save()
+    }
+  }
+  
+  func delete(_ id: UUID) async throws {
+    try await context.perform {
+      let request = CategoryEntity.fetchRequest()
+      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+      request.fetchLimit = 1
+      
+      guard let entity = try self.context.fetch(request).first else {
+        return
+      }
+      
+      self.context.delete(entity)
+      try self.context.save()
+    }
+  }
+}

--- a/BillKeeper/Sources/Data/Persistent/Repositories/CategoryRepositoryImpl.swift
+++ b/BillKeeper/Sources/Data/Persistent/Repositories/CategoryRepositoryImpl.swift
@@ -24,10 +24,7 @@ final class CategoryRepositoryImpl: CategoryRepository {
   
   func fetch(by id: UUID) async throws -> Category? {
     try await context.perform {
-      let request = CategoryEntity.fetchRequest()
-      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-      request.fetchLimit = 1
-      let entity = try self.context.fetch(request).first
+      let entity = try self.fetchEntity(by: id)
       return entity?.toDomain()
     }
   }
@@ -44,11 +41,7 @@ final class CategoryRepositoryImpl: CategoryRepository {
   
   func update(_ category: Category) async throws {
     try await context.perform {
-      let request = CategoryEntity.fetchRequest()
-      request.predicate = NSPredicate(format: "id == %@", category.id as CVarArg)
-      request.fetchLimit = 1
-      
-      guard let entity = try self.context.fetch(request).first else {
+      guard let entity = try self.fetchEntity(by: category.id) else {
         throw RepositoryError.notFound
       }
       
@@ -60,16 +53,19 @@ final class CategoryRepositoryImpl: CategoryRepository {
   
   func delete(_ id: UUID) async throws {
     try await context.perform {
-      let request = CategoryEntity.fetchRequest()
-      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-      request.fetchLimit = 1
-      
-      guard let entity = try self.context.fetch(request).first else {
+      guard let entity = try self.fetchEntity(by: id) else {
         return
       }
       
       self.context.delete(entity)
       try self.context.save()
     }
+  }
+  
+  private func fetchEntity(by id: UUID) throws -> CategoryEntity? {
+    let request = CategoryEntity.fetchRequest()
+    request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+    request.fetchLimit = 1
+    return try context.fetch(request).first
   }
 }

--- a/BillKeeper/Sources/Data/Persistent/Repositories/PaymentMethodRepositoryImpl.swift
+++ b/BillKeeper/Sources/Data/Persistent/Repositories/PaymentMethodRepositoryImpl.swift
@@ -24,10 +24,7 @@ final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
   
   func fetch(by id: UUID) async throws -> PaymentMethod? {
     try await context.perform {
-      let request = PaymentMethodEntity.fetchRequest()
-      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-      request.fetchLimit = 1
-      let entity = try self.context.fetch(request).first
+      let entity = try self.fetchEntity(by: id)
       return entity?.toDomain()
     }
   }
@@ -44,11 +41,7 @@ final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
   
   func update(_ paymentMethod: PaymentMethod) async throws {
     try await context.perform {
-      let request = PaymentMethodEntity.fetchRequest()
-      request.predicate = NSPredicate(format: "id == %@", paymentMethod.id as CVarArg)
-      request.fetchLimit = 1
-      
-      guard let entity = try self.context.fetch(request).first else {
+      guard let entity = try self.fetchEntity(by: paymentMethod.id) else {
         throw RepositoryError.notFound
       }
       
@@ -60,16 +53,19 @@ final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
   
   func delete(_ id: UUID) async throws {
     try await context.perform {
-      let request = PaymentMethodEntity.fetchRequest()
-      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-      request.fetchLimit = 1
-      
-      guard let entity = try self.context.fetch(request).first else {
+      guard let entity = try self.fetchEntity(by: id) else {
         return
       }
       
       self.context.delete(entity)
       try self.context.save()
     }
+  }
+  
+  private func fetchEntity(by id: UUID) throws -> PaymentMethodEntity? {
+    let request = PaymentMethodEntity.fetchRequest()
+    request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+    request.fetchLimit = 1
+    return try context.fetch(request).first
   }
 }

--- a/BillKeeper/Sources/Data/Persistent/Repositories/PaymentMethodRepositoryImpl.swift
+++ b/BillKeeper/Sources/Data/Persistent/Repositories/PaymentMethodRepositoryImpl.swift
@@ -1,0 +1,75 @@
+//
+//  PaymentMethodRepositoryImpl.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/28/25.
+//
+
+import CoreData
+
+final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
+  private let context: NSManagedObjectContext
+  
+  init(context: NSManagedObjectContext) {
+    self.context = context
+  }
+  
+  func fetchAll() async throws -> [PaymentMethod] {
+    try await context.perform {
+      let request = PaymentMethodEntity.fetchRequest()
+      let entities = try self.context.fetch(request)
+      return entities.map { $0.toDomain() }
+    }
+  }
+  
+  func fetch(by id: UUID) async throws -> PaymentMethod? {
+    try await context.perform {
+      let request = PaymentMethodEntity.fetchRequest()
+      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+      request.fetchLimit = 1
+      let entity = try self.context.fetch(request).first
+      return entity?.toDomain()
+    }
+  }
+  
+  func save(_ paymentMethod: PaymentMethod) async throws {
+    try await context.perform {
+      let entity = PaymentMethodEntity(context: self.context)
+      entity.id = paymentMethod.id
+      entity.name = paymentMethod.name
+      entity.isDefault = paymentMethod.isDefault
+      try self.context.save()
+    }
+  }
+  
+  func update(_ paymentMethod: PaymentMethod) async throws {
+    try await context.perform {
+      let request = PaymentMethodEntity.fetchRequest()
+      request.predicate = NSPredicate(format: "id == %@", paymentMethod.id as CVarArg)
+      request.fetchLimit = 1
+      
+      guard let entity = try self.context.fetch(request).first else {
+        throw RepositoryError.notFound
+      }
+      
+      entity.name = paymentMethod.name
+      entity.isDefault = paymentMethod.isDefault
+      try self.context.save()
+    }
+  }
+  
+  func delete(_ id: UUID) async throws {
+    try await context.perform {
+      let request = PaymentMethodEntity.fetchRequest()
+      request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+      request.fetchLimit = 1
+      
+      guard let entity = try self.context.fetch(request).first else {
+        return
+      }
+      
+      self.context.delete(entity)
+      try self.context.save()
+    }
+  }
+}

--- a/BillKeeper/Sources/Domain/Repositories/RepositoryError.swift
+++ b/BillKeeper/Sources/Domain/Repositories/RepositoryError.swift
@@ -1,0 +1,13 @@
+//
+//  RepositoryError.swift
+//  BillKeeper
+//
+//  Created by LCH on 10/28/25.
+//
+
+import Foundation
+
+enum RepositoryError: Error, Equatable {
+  case notFound
+  case relatedEntityNotFound(String)
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #22

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- Domain/Repositories에 RepositoryError enum 추가
  - Repository 구현체에서 공통으로 사용하는 기본 에러를 정의했습니다.
- Domain/Repositories의 protocol을 따르는 CategoryRepositoryImpl / PaymentMethodRepositoryImpl 구현
  - 각 Domain 데이터 접근 로직을 CoreData 기반으로 구현했습니다. 
- Data 계층의 Category, PaymentMethod, RecurringData Entity 확장을 통합하고 MARK 구문으로 구분
  - 중복된 extension 파일을 정리하고 구조를 명확히 했습니다. 
- Data 계층의 Category, PaymentMethod Entity에 toDomain() 메서드 추가
  - Entity를 Domain 모델로 변환할 수 있도록 매핑 로직을 추가했습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 현재 개인 진행 프로젝트로, 기록 목적의 PR입니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- Transaction Repository의 구현체 TransactionRepositoryImpl은 RRule 기반 반복 규칙 처리와 관련 라이브러리 추가가 필요해 별도 이슈로 진행 예정입니다.

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
- [x] 컴파일 정상 확인
