### PR TITLE
[Chore] #25 - SwiftLint와 SwiftFormat 규칙 충돌에 따른 SwiftFormat 규칙 변경

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -6,9 +6,9 @@
 
 # 줄바꿈, 공백 관련 설정
 --stripunusedargs closure-only
---wraparguments after-first
+--wraparguments before-first
 --wrapcollections before-first
---trimwhitespace nonblank-lines
+--trimwhitespace always
 --commas inline
 --semicolons never
 --disable consecutiveBlankLines

--- a/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/CategoryEntity+.swift
@@ -10,44 +10,46 @@ import CoreData
 
 extension CategoryEntity {
   // MARK: - Fetch Request
-  
+
   @nonobjc class func fetchRequest() -> NSFetchRequest<CategoryEntity> {
     return NSFetchRequest<CategoryEntity>(entityName: "Category")
   }
-  
+
   // MARK: - Domain Mapping
-  
+
   func toDomain() -> Category {
-    return Category(id: id,
-                    name: name,
-                    isDefault: isDefault)
+    return Category(
+      id: id,
+      name: name,
+      isDefault: isDefault
+    )
   }
-  
+
   // MARK: - RecurringData Relationship
-  
+
   @objc(addRecurringDataObject:)
   @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
-  
+
   @objc(removeRecurringDataObject:)
   @NSManaged func removeFromRecurringData(_ value: RecurringDataEntity)
-  
+
   @objc(addRecurringData:)
   @NSManaged func addToRecurringData(_ values: NSSet)
-  
+
   @objc(removeRecurringData:)
   @NSManaged func removeFromRecurringData(_ values: NSSet)
-  
+
   // MARK: - Transactions Relationship
-  
+
   @objc(addTransactionsObject:)
   @NSManaged func addToTransactions(_ value: TransactionEntity)
-  
+
   @objc(removeTransactionsObject:)
   @NSManaged func removeFromTransactions(_ value: TransactionEntity)
-  
+
   @objc(addTransactions:)
   @NSManaged func addToTransactions(_ values: NSSet)
-  
+
   @objc(removeTransactions:)
   @NSManaged func removeFromTransactions(_ values: NSSet)
 }

--- a/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/PaymentMethodEntity+.swift
@@ -10,44 +10,46 @@ import CoreData
 
 extension PaymentMethodEntity {
   // MARK: - Fetch Request
-  
+
   @nonobjc class func fetchRequest() -> NSFetchRequest<PaymentMethodEntity> {
     return NSFetchRequest<PaymentMethodEntity>(entityName: "PaymentMethod")
   }
-  
+
   // MARK: - Domain Mapping
-  
+
   func toDomain() -> PaymentMethod {
-    return PaymentMethod(id: id,
-                         name: name,
-                         isDefault: isDefault)
+    return PaymentMethod(
+      id: id,
+      name: name,
+      isDefault: isDefault
+    )
   }
-  
+
   // MARK: - RecurringData Relationship
-  
+
   @objc(addRecurringDataObject:)
   @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
-  
+
   @objc(removeRecurringDataObject:)
   @NSManaged func removeFromRecurringData(_ value: RecurringDataEntity)
-  
+
   @objc(addRecurringData:)
   @NSManaged func addToRecurringData(_ values: NSSet)
-  
+
   @objc(removeRecurringData:)
   @NSManaged func removeFromRecurringData(_ values: NSSet)
-  
+
   // MARK: - Transactions Relationship
-  
+
   @objc(addTransactionsObject:)
   @NSManaged func addToTransactions(_ value: TransactionEntity)
-  
+
   @objc(removeTransactionsObject:)
   @NSManaged func removeFromTransactions(_ value: TransactionEntity)
-  
+
   @objc(addTransactions:)
   @NSManaged func addToTransactions(_ values: NSSet)
-  
+
   @objc(removeTransactions:)
   @NSManaged func removeFromTransactions(_ values: NSSet)
 }

--- a/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/RecurringDataEntity+.swift
@@ -10,7 +10,7 @@ import CoreData
 
 extension RecurringDataEntity {
   // MARK: - Fetch Request
-  
+
   @nonobjc class func fetchRequest() -> NSFetchRequest<RecurringDataEntity> {
     return NSFetchRequest<RecurringDataEntity>(entityName: "RecurringData")
   }

--- a/BillKeeper/Sources/Data/Persistent/Entities/TransactionEntity+.swift
+++ b/BillKeeper/Sources/Data/Persistent/Entities/TransactionEntity+.swift
@@ -17,13 +17,13 @@ extension TransactionEntity {
 extension TransactionEntity {
   @objc(addRecurringDataObject:)
   @NSManaged func addToRecurringData(_ value: RecurringDataEntity)
-  
+
   @objc(removeRecurringDataObject:)
   @NSManaged func removeFromRecurringData(_ value: RecurringDataEntity)
-  
+
   @objc(addRecurringData:)
   @NSManaged func addToRecurringData(_ values: NSSet)
-  
+
   @objc(removeRecurringData:)
   @NSManaged func removeFromRecurringData(_ values: NSSet)
 }

--- a/BillKeeper/Sources/Data/Persistent/Repositories/CategoryRepositoryImpl.swift
+++ b/BillKeeper/Sources/Data/Persistent/Repositories/CategoryRepositoryImpl.swift
@@ -9,11 +9,11 @@ import CoreData
 
 final class CategoryRepositoryImpl: CategoryRepository {
   private let context: NSManagedObjectContext
-  
+
   init(context: NSManagedObjectContext) {
     self.context = context
   }
-  
+
   func fetchAll() async throws -> [Category] {
     try await context.perform {
       let request = CategoryEntity.fetchRequest()
@@ -21,14 +21,14 @@ final class CategoryRepositoryImpl: CategoryRepository {
       return entities.map { $0.toDomain() }
     }
   }
-  
+
   func fetch(by id: UUID) async throws -> Category? {
     try await context.perform {
       let entity = try self.fetchEntity(by: id)
       return entity?.toDomain()
     }
   }
-  
+
   func save(_ category: Category) async throws {
     try await context.perform {
       let entity = CategoryEntity(context: self.context)
@@ -38,30 +38,30 @@ final class CategoryRepositoryImpl: CategoryRepository {
       try self.context.save()
     }
   }
-  
+
   func update(_ category: Category) async throws {
     try await context.perform {
       guard let entity = try self.fetchEntity(by: category.id) else {
         throw RepositoryError.notFound
       }
-      
+
       entity.name = category.name
       entity.isDefault = category.isDefault
       try self.context.save()
     }
   }
-  
+
   func delete(_ id: UUID) async throws {
     try await context.perform {
       guard let entity = try self.fetchEntity(by: id) else {
         return
       }
-      
+
       self.context.delete(entity)
       try self.context.save()
     }
   }
-  
+
   private func fetchEntity(by id: UUID) throws -> CategoryEntity? {
     let request = CategoryEntity.fetchRequest()
     request.predicate = NSPredicate(format: "id == %@", id as CVarArg)

--- a/BillKeeper/Sources/Data/Persistent/Repositories/PaymentMethodRepositoryImpl.swift
+++ b/BillKeeper/Sources/Data/Persistent/Repositories/PaymentMethodRepositoryImpl.swift
@@ -9,11 +9,11 @@ import CoreData
 
 final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
   private let context: NSManagedObjectContext
-  
+
   init(context: NSManagedObjectContext) {
     self.context = context
   }
-  
+
   func fetchAll() async throws -> [PaymentMethod] {
     try await context.perform {
       let request = PaymentMethodEntity.fetchRequest()
@@ -21,14 +21,14 @@ final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
       return entities.map { $0.toDomain() }
     }
   }
-  
+
   func fetch(by id: UUID) async throws -> PaymentMethod? {
     try await context.perform {
       let entity = try self.fetchEntity(by: id)
       return entity?.toDomain()
     }
   }
-  
+
   func save(_ paymentMethod: PaymentMethod) async throws {
     try await context.perform {
       let entity = PaymentMethodEntity(context: self.context)
@@ -38,30 +38,30 @@ final class PaymentMethodRepositoryImpl: PaymentMethodRepository {
       try self.context.save()
     }
   }
-  
+
   func update(_ paymentMethod: PaymentMethod) async throws {
     try await context.perform {
       guard let entity = try self.fetchEntity(by: paymentMethod.id) else {
         throw RepositoryError.notFound
       }
-      
+
       entity.name = paymentMethod.name
       entity.isDefault = paymentMethod.isDefault
       try self.context.save()
     }
   }
-  
+
   func delete(_ id: UUID) async throws {
     try await context.perform {
       guard let entity = try self.fetchEntity(by: id) else {
         return
       }
-      
+
       self.context.delete(entity)
       try self.context.save()
     }
   }
-  
+
   private func fetchEntity(by id: UUID) throws -> PaymentMethodEntity? {
     let request = PaymentMethodEntity.fetchRequest()
     request.predicate = NSPredicate(format: "id == %@", id as CVarArg)

--- a/BillKeeper/Sources/Shared/Utilities/FontUtility.swift
+++ b/BillKeeper/Sources/Shared/Utilities/FontUtility.swift
@@ -13,7 +13,7 @@ enum FontUtility {
     case medium = "PretendardVariable-Medium"
     case regular = "PretendardVariable-Regular"
   }
-  
+
   static func resolveFont(weight: Weight, size: CGFloat) -> UIFont {
     if let font = UIFont(name: weight.rawValue, size: size) {
       return font

--- a/BillKeeper/Sources/Shared/Utilities/UIColor+Hex.swift
+++ b/BillKeeper/Sources/Shared/Utilities/UIColor+Hex.swift
@@ -13,9 +13,9 @@ extension UIColor {
     hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
     guard [6, 8].contains(hexSanitized.count) else { return nil }
     let hasAlpha = hexSanitized.count == 8
-    
+
     guard let rgba = UInt32(hexSanitized, radix: 16) else { return nil }
-    
+
     let divisor = CGFloat(255)
     let red, green, blue, alpha: CGFloat
     if hasAlpha {
@@ -29,7 +29,7 @@ extension UIColor {
       blue = CGFloat(rgba & 0x0000FF) / divisor
       alpha = CGFloat(1.0)
     }
-    
+
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/Scripts.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scripts.swift
@@ -3,9 +3,7 @@ import ProjectDescription
 public enum BuildScripts {
   public static let swiftLint = TargetScript.pre(
     script: """
-    export MISE_SHIMS="$HOME/.local/share/mise/shims"
-    export MISE_SWIFTLINT="$HOME/.local/share/mise/installs/swiftlint/0.62.1"
-    export PATH="$MISE_SHIMS:$MISE_SWIFTLINT:$PATH"
+    export PATH="$HOME/.local/share/mise/shims:$PATH"
     echo "< SwiftLint check running >"
     swiftlint lint --reporter xcode --config ${SRCROOT}/.swiftlint.yml || true
     """,
@@ -14,9 +12,7 @@ public enum BuildScripts {
   )
   public static let swiftFormat = TargetScript.pre(
     script: """
-    export MISE_SHIMS="$HOME/.local/share/mise/shims"
-    export MISE_SWIFTLINT="$HOME/.local/share/mise/installs/swiftlint/0.62.1"
-    export PATH="$MISE_SHIMS:$MISE_SWIFTLINT:$PATH"
+    export PATH="$HOME/.local/share/mise/shims:$PATH"
     echo "< SwiftFormat check running >"
     swiftformat ${SRCROOT} --swiftversion 6.1.2 --quiet || true
     """,


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #25

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- SwiftLint와 SwiftFormat 규칙 충돌 해결
  - wraparguments 규칙 after-first -> before-first 로 수정하여 SwiftLint(opening_brace) 규칙과 일치시켰습니다.
  - 불필요한 공백 삭제를 위해 trimwhitespace 규칙 nonblank-lines -> always로 수정하였습니다.
- 빌드 스크립트 PATH 정리
  - TargetScript pre에서 Xcode Build Phases 환경과 일관성을 유지하기 위해 PATH를 명시적으로 지정했습니다.
  - eval "$(mise activate ...)" 명령어가 정상적으로 동작하지 않는 환경을 고려하여, mise/shims 경로로 고정했습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 현재 개인 진행 프로젝트로, 기록 목적의 PR입니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 규칙 변경으로 인해 일부 파일의 공백, 중괄호 위치 등이 자동 수정되었습니다.
- 스크립트 수정은 빌드 환경 보정 목적이며, 기능적 변경은 없습니다.

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
- [x] 컴파일 정상 확인
